### PR TITLE
feat(claude-code): add dreamer skill to curate memories into howm

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -3,6 +3,11 @@
     "type": "command",
     "command": "~/.claude/scripts/file-suggestion.sh"
   },
+  {{- if eq .chezmoi.hostname "capaldi-phampc" }}
+  "autoMemoryDirectory": "/mnt/c/Users/xavie/notes/inbox",
+  {{- else }}
+  "autoMemoryDirectory": "~/Notes/inbox",
+  {{- end }}
   "env": {
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
     "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": "1",

--- a/dot_claude/skills/dreamer/SKILL.md
+++ b/dot_claude/skills/dreamer/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: dreamer
+description: "Consolidate new Claude memories and howm captures into the persistent note graph. Reads scratch memories, unprocessed howm captures and recent session transcripts, then merges, promotes or drops each one and rewrites MEMORY.md as an index. Use when the user asks to dream, to process memories, or to tidy the note graph."
+user-invocable: true
+---
+
+# Dreamer
+
+Claude writes memories during the day. They are fast, local and unverified, so they duplicate each other and go stale. This skill is the curation pass that turns them into notes in the howm graph.
+
+The graph is the store of truth. `MEMORY.md` is only an index that points into it.
+
+## Layout
+
+| Path | Role |
+|---|---|
+| `~/Notes/` | howm graph. Persistent notes. Git tracked. |
+| `~/Notes/inbox/` | `autoMemoryDirectory`. Scratch memories Claude wrote today. |
+| `~/Notes/inbox/MEMORY.md` | Index loaded into every session. Excluded from howm indexing. |
+| `~/Notes/inbox/.dream-state` | ISO timestamp of the last run. Dot prefix hides it from howm. |
+| `~/Notes/.howm-keys` | Controlled vocabulary. |
+
+On the WSL host the notes root is `/mnt/c/Users/xavie/notes/` instead. Read `howm-directory` from `dot_config/emacs/init.el` if unsure.
+
+`~/Notes/inbox/` is a subdirectory on purpose. Claude's auto memory only writes inside `autoMemoryDirectory`, so it can never edit or delete a persistent note. This skill is the only actor that touches `~/Notes/*.md`.
+
+## Three states
+
+| Form | Location | Meaning |
+|---|---|---|
+| `some-slug.md` | `inbox/` | Scratch memory. Needs promotion. |
+| `20260730T140800.md` | `~/Notes/` | howm quick capture. Needs a name and tags. |
+| `20260730T140800--title__kw1_kw2.md` | `~/Notes/` | Processed. |
+
+Consume the first two. Only ever emit the third. Move a scratch file out of `inbox/` when you promote or merge it, so presence in `inbox/` always means unprocessed. Never invent bookkeeping that duplicates this signal.
+
+## Procedure
+
+### 1. Read the vocabulary first
+
+```sh
+cat ~/Notes/.howm-keys
+```
+
+Graph edges come from keyword co-occurrence, so an off-vocabulary tag creates a note that connects to nothing. Tag only from this list. A keyword that is not in the list is a tier 3 hold, never a silent addition.
+
+### 2. Collect the inputs
+
+Scratch memories and captures:
+
+```sh
+ls ~/Notes/inbox/*.md                       # exclude MEMORY.md
+find ~/Notes -maxdepth 1 -name '[0-9]*T[0-9]*.md' ! -name '*--*'
+```
+
+Transcripts, scoped to sessions since the last run:
+
+```sh
+cat ~/Notes/inbox/.dream-state              # ISO timestamp, absent on first run
+find ~/.claude/projects -name '*.jsonl' -newermt "$(cat ~/Notes/inbox/.dream-state)"
+```
+
+Transcripts run to tens of megabytes per day. Never read them directly. Spawn one subagent per transcript file and have each return only candidate insights, in this shape:
+
+```
+{claim, evidence_path, confidence, suggested_keywords}
+```
+
+Tell each subagent to return nothing rather than pad. Most sessions hold no durable insight. A transcript yielding zero candidates is the normal case.
+
+### 3. Decide per item
+
+Search the graph before deciding, so you find the note that already covers the topic:
+
+```sh
+rg -l --no-heading 'topic phrase' ~/Notes/
+```
+
+| Action | When |
+|---|---|
+| **merge** | A note already covers the topic. Keep its ID and filename. Add only the new fact. |
+| **promote** | Nothing covers it and the fact is durable. Write a new note. |
+| **drop** | Trivial, superseded, or already true in the graph. |
+| **hold** | Ambiguous. Leave the file in `inbox/` and ask in the digest. |
+
+### 4. Tier the actions
+
+Apply tiers 1 and 2 without asking. Every action is a git commit, so `git revert` is the undo.
+
+- **Tier 1, apply silently.** Name and tag captures. Remove exact duplicates. Promote a clean scratch memory to a new note.
+- **Tier 2, apply and report.** Merges. Contradictions you resolved by recency. List each in the digest.
+- **Tier 3, hold and ask.** Two notes that may be one concept. A contradiction with no clear recency winner. Any keyword not already in `.howm-keys`. Vocabulary changes are the user's call because every edge depends on them.
+
+### 5. Write notes
+
+Filename: `YYYYmmddTHHMMSS--title-slug__kw1_kw2.md`, minted from the current local time for a new note, or kept unchanged for a merge.
+
+Header, OKF style. `type` is required:
+
+```yaml
+---
+type: note
+title: Cloud SQL connection pressure
+tags: [infra, database]
+timestamp: 2026-07-30T14:08:00
+description: One line on why this note exists.
+---
+```
+
+The YAML is the source of truth. The filename slug and keywords are derived from `title` and `tags`, so change the YAML first and then the name.
+
+### 6. Guardrails when editing a note
+
+howm links are search based. `>>> foo` finds the literal text `foo`, so any edit to body text is a potential edit to a link, and a broken link fails silently instead of dangling.
+
+- Copy `>>>` and `<<<` lines through unchanged.
+- Append or make a surgical edit. Never rewrite a note body wholesale.
+- Never reword a heading or phrase that other notes point at. Check first: `rg -F '>>> phrase' ~/Notes/`.
+- Never delete a note the user wrote. Downgrade to a tier 3 hold and ask.
+
+### 7. Rewrite MEMORY.md
+
+One line per entry, pointing at a note path:
+
+```markdown
+- [Cloud SQL connection pressure](~/Notes/20260615T103300--cloudsql-connection-pressure__infra_database.md) — pool exhaustion under batch load
+```
+
+Only the first 200 lines or 25KB load into a session, and this index is shared by every project, so it fills fast. Keeping it short is the main job of this step. Push detail down into the note and leave a pointer. Merge or drop stale lines.
+
+### 8. Write the digest, then commit
+
+Write the digest as a note so it lands in the graph and stays searchable:
+
+`YYYYmmddTHHMMSS--dream-digest__meta.md`
+
+Include the counts for each action, every tier 2 item, and a questions section for the tier 3 holds. Put a howm reminder marker on the questions so the menu keeps showing them until they are resolved. Use `-` for a plain reminder, or `!` for a deadline if an answer blocks later work:
+
+```markdown
+## Questions
+
+[2026-07-31]- Is "connection pooling" the same concept as the existing "pool pressure" note?
+```
+
+The user answers in the digest. Read the previous digest at the start of the next run and act on the answers.
+
+Then record the run and commit:
+
+```sh
+date -u +%Y-%m-%dT%H:%M:%SZ > ~/Notes/inbox/.dream-state
+git -C ~/Notes add -A && git -C ~/Notes commit -m "chore: dream <date>"
+```
+
+Report to the user what changed. State the counts plainly and name any holds.
+
+## First run
+
+`~/Notes/` starts empty and `.howm-keys` holds no real vocabulary, so the first run is a bootstrap, not a maintenance pass. It seeds the graph from the memories that already exist in the per-project directories under `~/.claude/projects/*/memory/`.
+
+Run this one interactively. Two things make it different:
+
+1. **Propose the vocabulary and stop.** Cluster the memories, propose a keyword list, and get approval before writing any note. Everything downstream depends on this list, and a bad list is expensive to undo once notes are tagged.
+2. **Propose the groupings.** Many of the memories overlap. Show the merge plan before you write.
+
+Only after both are approved, promote the notes, write `.howm-keys`, and make the first commit.
+
+## Notes on tooling
+
+Plain shell is enough: `cat` for the vocabulary, `rg` for search, `Write` for notes, an append for a new keyword. The old `howm-cli.el` helper is recoverable at `git show 49528830^:dot_claude/skills/howm/howm-cli.el`. Restore it only if this skill needs howm's real task priority or come-from resolution semantics, which plain text handling cannot reproduce.

--- a/dot_config/emacs/init.el
+++ b/dot_config/emacs/init.el
@@ -475,6 +475,12 @@
                      "00000000T000000.txt")
                    xcc/howm-directory))
   :config
+  ;; Claude Code writes its memories into <howm-directory>/inbox, so they are
+  ;; searchable as soon as they are written. MEMORY.md is an index of that
+  ;; directory rather than a note, so keep it out of the graph.
+  (unless (string-match-p "MEMORY" howm-excluded-file-regexp)
+    (setq howm-excluded-file-regexp
+          (concat howm-excluded-file-regexp "\\|\\(^\\|/\\)MEMORY\\.md\\'")))
   ;; Howm's menu entry point only generates the skeleton template when
   ;; `howm-menu-file' is nil; with it set, opening the menu would just
   ;; find-file an empty buffer. So generate the skeleton into that path


### PR DESCRIPTION
## What

Adds a `dreamer` skill that consolidates Claude's scratch memories into the howm note graph, plus the two config changes it needs.

Claude writes memories as it works. They are fast and unverified, so over weeks they duplicate each other and go stale. There are already 53 of them spread across four per-project directories, while `~/Notes/` is empty. The dreamer is the curation pass: it reads scratch memories, unprocessed howm captures and recent session transcripts, then merges, promotes, drops or holds each one and rewrites `MEMORY.md` as a thin index into the graph.

## Where memory lives

`autoMemoryDirectory` now points at `<howm-directory>/inbox`. One directory is shared by every project, because all work on this machine is related.

The inbox is a **subdirectory**, not the notes root. Auto memory only writes inside `autoMemoryDirectory`, so it cannot edit or delete a persistent note. That matters more than it first appears: auto-memory instructions tell Claude to update an existing file rather than duplicate it, and to delete memories that turn out to be wrong. Pointed at the notes root, those instructions would apply to hand-written notes. howm links are search based, so a silent reword breaks a link without dangling and without any error. A subdirectory removes the risk mechanically instead of relying on good judgement.

howm still indexes the inbox, so a new memory is searchable as soon as it is written. No symlink is needed.

## Verified behaviour

howm searches recursively through `directory-files-recursively` (`howm-backend.el:120`), filtered by `howm-excluded-file-regexp`, whose default skips any path component that starts with a dot. Tested against sample paths:

| Path | Indexed |
|---|---|
| `20260730T140800--foo__infra.md` | yes |
| `inbox/some-slug.md` | yes |
| `inbox/MEMORY.md` | no |
| `inbox/.dream-state` | no |
| `00000000T000000.md` (menu) | yes |

`MEMORY.md` needs the explicit regexp entry because it has no dot prefix. `.dream-state` is hidden for free.

## Invocation

The skill is invoked by hand. Scheduling was considered and dropped: Claude Code cron jobs only fire while a REPL sits idle and recurring jobs expire after 7 days, and plugin monitors stop when the session ends. Neither can drive an unattended end-of-day run. launchd is the option if scheduling is wanted later.

## Review model

Actions are tiered so the pass does not become a queue to approve. Naming, tagging and clean promotions apply silently. Merges and recency-resolved contradictions apply and get reported. Genuine ambiguity, and **any keyword not already in `.howm-keys`**, is held and asked about, because every graph edge depends on that vocabulary. Questions land in a digest note carrying a howm reminder marker, so the menu keeps showing them until they are answered. Each run is one git commit, so `git revert` is the undo.

## First run

`~/Notes/` is empty and `.howm-keys` holds no real vocabulary, so the first run is a bootstrap rather than a maintenance pass. The skill runs it interactively: propose the keyword list and the merge groupings, get approval, then write. A bad vocabulary is expensive to undo once notes are tagged.

## Not included

Transcript scanning is in scope but fans out to one subagent per file. 23 transcripts totalling 44&nbsp;MB were touched in a single day, which is far too much to read directly.

## Test

- `chezmoi execute-template` on `settings.json.tmpl` renders valid JSON with the expected path.
- The exclusion regexp was checked in `emacs --batch` against the seven paths above.
- Nothing is applied to the live system yet. `chezmoi apply` is still needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)